### PR TITLE
Possible suggestion for GPUs with only one performance state (P100, V100, etc) #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ Suppose you have 8 GPUs and you want to manage only the first 4 (as in `nvidia-s
 
 ### GPUs without performance states
 
-Some GPUs (Tesla P100, V100, etc) expose a single performance state, so `NvAPI_GPU_SetForcePstate` always fails on them and the daemon exits with:
+Some GPUs (Tesla P100, V100, etc) expose only a single performance state (a memory clock), so `NvAPI_GPU_SetForcePstate` always fails on them and the daemon exits with:
 
 ```text
 NvAPI_GPU_SetForcePstate(nvapiDevices[i], pstateId, 0): NVAPI_NOT_SUPPORTED
 If GPU 0 does not support performance states, restart the daemon with --clock-mode.
 ```
 
-On these GPUs you can use `-c`/`--clock-mode`, which controls the GPU clocks (as `nvidia-smi -lgc` does) instead of forcing a performance state:
+On these GPUs you can use `-c`/`--clock-mode`, which controls the GPU clocks (as `nvidia-smi -lgc` does) instead of changing performance states:
 
 ```sh
 ./nvidia-pstated --clock-mode
@@ -171,12 +171,12 @@ Note that clock mode requires root/admin permissions.
 
 The daemon picks the mechanism per GPU, from its architecture:
 
-| GPU | Mechanism | Memory clocks |
-| --- | --- | --- |
-| Volta and newer (V100, etc) | `nvmlDeviceSetGpuLockedClocks` | Only managed if `--clock-mem-low` or `--clock-mem-high` is set, as locking them requires an Ampere or newer GPU |
-| Older than Volta (P100, etc) | `nvmlDeviceSetApplicationsClocks` | Always set, as the call takes both domains at once; defaults to the lowest supported clock |
+| GPU              | Mechanism           | Memory clocks                                                                                                   |
+| ---------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Volta and newer  | Locked clocks       | Only managed if `--clock-mem-low` or `--clock-mem-high` is set, as locking them requires an Ampere or newer GPU |
+| Older than Volta | Applications clocks | Always set, as the call takes both domains at once; defaults to the lowest supported clock                      |
 
-Applications clocks are deprecated since NVML 13.0 and are removed in CUDA 14.0, so they are only compiled in when the CUDA toolkit used to build still provides them. Checking the architecture is enough to know they are available at runtime, since the last driver branch supporting pre-Volta GPUs is 580, which still provides them.
+Applications clocks are deprecated since NVML 13.0 and are removed in CUDA 14.0, so they are only compiled in when the CUDA toolkit used to build still provides them.
 
 On GPUs older than Volta, `--clock-gpu-high` and `--clock-mem-high` have to be set together to pin the high performance state; if either is left at `0`, the default clocks are restored instead.
 

--- a/README.md
+++ b/README.md
@@ -153,34 +153,46 @@ NvAPI_GPU_SetForcePstate(nvapiDevices[i], pstateId, 0): NVAPI_NOT_SUPPORTED
 If GPU 0 does not support performance states, restart the daemon with --clock-mode.
 ```
 
-On these GPUs you can use `-c`/`--clock-mode`, which locks and unlocks the GPU clocks (as `nvidia-smi -lgc` does) instead of forcing a performance state:
+On these GPUs you can use `-c`/`--clock-mode`, which controls the GPU clocks (as `nvidia-smi -lgc` does) instead of forcing a performance state:
 
 ```sh
 ./nvidia-pstated --clock-mode
 ```
 
-By default, the daemon locks the graphics clock to the lowest clock the GPU reports in the low performance state, and restores the default clocks in the high performance state. Both values can be overridden with `--clock-gpu-low` and `--clock-gpu-high`:
+By default, the daemon sets the graphics clock to the lowest clock the GPU reports in the low performance state, and restores the default clocks in the high performance state. Both values can be overridden with `--clock-gpu-low` and `--clock-gpu-high`:
 
 ```sh
 ./nvidia-pstated --clock-mode --clock-gpu-low 135 --clock-gpu-high 1380
 ```
 
-Memory clocks are left untouched unless `--clock-mem-low` or `--clock-mem-high` is set, because locking them requires an Ampere or newer GPU, while locking the graphics clocks only requires a Volta or newer one.
-
 Note that clock mode requires root/admin permissions.
+
+#### Which mechanism is used
+
+The daemon picks the mechanism per GPU, from its architecture:
+
+| GPU | Mechanism | Memory clocks |
+| --- | --- | --- |
+| Volta and newer (V100, etc) | `nvmlDeviceSetGpuLockedClocks` | Only managed if `--clock-mem-low` or `--clock-mem-high` is set, as locking them requires an Ampere or newer GPU |
+| Older than Volta (P100, etc) | `nvmlDeviceSetApplicationsClocks` | Always set, as the call takes both domains at once; defaults to the lowest supported clock |
+
+Applications clocks are deprecated since NVML 13.0 and are removed in CUDA 14.0, so they are only compiled in when the CUDA toolkit used to build still provides them. Checking the architecture is enough to know they are available at runtime, since the last driver branch supporting pre-Volta GPUs is 580, which still provides them.
+
+On GPUs older than Volta, `--clock-gpu-high` and `--clock-mem-high` have to be set together to pin the high performance state; if either is left at `0`, the default clocks are restored instead.
 
 ### Recovering from a crash
 
-If the daemon is killed before it can restore the clocks (`SIGKILL`, power loss, etc), the GPUs are left locked to the low performance clocks. To unlock them:
+If the daemon is killed before it can restore the clocks (`SIGKILL`, power loss, etc), the GPUs are left at the low performance clocks. To restore the default ones:
 
 ```sh
+# Volta and newer
 nvidia-smi -rgc
-```
 
-If you were also managing memory clocks, unlock them as well:
-
-```sh
+# also needed if memory clocks were managed
 nvidia-smi -rmc
+
+# older than Volta
+nvidia-smi -rac
 ```
 
 ### systemd service

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ flowchart TD
     subgraph For each GPU
     CHECK_TEMPERATURE("Check temperature[1]") -->|Below threshold| CHECK_UTILIZATION
     CHECK_TEMPERATURE("Check temperature[1]") -->|Above threshold| ENTER_LOW_PSTATE_0
-    ENTER_LOW_PSTATE_0("Enter low PState[2]") --> ENTER_HIGH_FAN_STATE_0
+    ENTER_LOW_PSTATE_0("Enter low PState[2][10]") --> ENTER_HIGH_FAN_STATE_0
     ENTER_HIGH_FAN_STATE_0("Enter high fan state[9]") --> END
     CHECK_UTILIZATION("Check utilization[3]") -->|Below threshold| CHECK_CURRENT_PSTATE_0
     CHECK_UTILIZATION("Check utilization[3]") -->|Above threshold| CHECK_CURRENT_PSTATE_1
@@ -18,7 +18,7 @@ flowchart TD
     CHECK_CURRENT_PSTATE_0(Check current PState) -->|Low| DO_NOTHING
     ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_0("Iterations counter exceeded threshold[4]") -->|Yes| ENTER_LOW_PSTATE
     ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_0("Iterations counter exceeded threshold[4]") -->|No| ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_1
-    ENTER_LOW_PSTATE("Enter low PState[2]") --> ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_1
+    ENTER_LOW_PSTATE("Enter low PState[2][10]") --> ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_1
     ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_1("Iterations counter exceeded threshold[7]") -->|Yes| ENTER_LOW_FAN_STATE_1
     ITERATIONS_COUNTER_EXCEEDED_THRESHOLD_1("Iterations counter exceeded threshold[7]") -->|No| INCREMENT_ITERATIONS_COUNTER
     ENTER_LOW_FAN_STATE_1("Enter low fan state[8]") --> INCREMENT_ITERATIONS_COUNTER
@@ -27,7 +27,7 @@ flowchart TD
     CHECK_CURRENT_PSTATE_1(Check current PState) -->|High| RESET_ITERATIONS_COUNTER
     CHECK_CURRENT_PSTATE_1(Check current PState) -->|Low| ENTER_HIGH_PSTATE
     RESET_ITERATIONS_COUNTER(Reset iterations counter) --> END
-    ENTER_HIGH_PSTATE("Enter high PState[5]") --> ENTER_HIGH_FAN_STATE_1
+    ENTER_HIGH_PSTATE("Enter high PState[5][11]") --> ENTER_HIGH_FAN_STATE_1
     ENTER_HIGH_FAN_STATE_1("Enter high fan state[9]") --> END
     end
     END(End) --> SLEEP
@@ -42,7 +42,9 @@ flowchart TD
 6 - Value is controlled by option `--sleep-interval` (default: `100` milliseconds)  
 7 - Threshold is controlled by option `--iterations-before-idle` (default: `9000` iterations)  
 8 - Value is controlled by option `--disable-fan-script` (default: none)  
-9 - Value is controlled by option `--enable-fan-script` (default: none)
+9 - Value is controlled by option `--enable-fan-script` (default: none)  
+10 - In clock mode, values are controlled by options `--clock-gpu-low` (default: `0` MHz) and `--clock-mem-low` (default: `0` MHz)  
+11 - In clock mode, values are controlled by options `--clock-gpu-high` (default: `0` MHz) and `--clock-mem-high` (default: `0` MHz)
 
 ## Installation
 
@@ -142,6 +144,45 @@ Suppose you have 8 GPUs and you want to manage only the first 4 (as in `nvidia-s
 ./nvidia-pstated -i 0,1,2,3
 ```
 
+### GPUs without performance states
+
+Some GPUs (Tesla P100, V100, etc) expose a single performance state, so `NvAPI_GPU_SetForcePstate` always fails on them and the daemon exits with:
+
+```text
+NvAPI_GPU_SetForcePstate(nvapiDevices[i], pstateId, 0): NVAPI_NOT_SUPPORTED
+If GPU 0 does not support performance states, restart the daemon with --clock-mode.
+```
+
+On these GPUs you can use `-c`/`--clock-mode`, which locks and unlocks the GPU clocks (as `nvidia-smi -lgc` does) instead of forcing a performance state:
+
+```sh
+./nvidia-pstated --clock-mode
+```
+
+By default, the daemon locks the graphics clock to the lowest clock the GPU reports in the low performance state, and restores the default clocks in the high performance state. Both values can be overridden with `--clock-gpu-low` and `--clock-gpu-high`:
+
+```sh
+./nvidia-pstated --clock-mode --clock-gpu-low 135 --clock-gpu-high 1380
+```
+
+Memory clocks are left untouched unless `--clock-mem-low` or `--clock-mem-high` is set, because locking them requires an Ampere or newer GPU, while locking the graphics clocks only requires a Volta or newer one.
+
+Note that clock mode requires root/admin permissions.
+
+### Recovering from a crash
+
+If the daemon is killed before it can restore the clocks (`SIGKILL`, power loss, etc), the GPUs are left locked to the low performance clocks. To unlock them:
+
+```sh
+nvidia-smi -rgc
+```
+
+If you were also managing memory clocks, unlock them as well:
+
+```sh
+nvidia-smi -rmc
+```
+
 ### systemd service
 
 Install `nvidia-pstated` in `/usr/local/bin`. Then save the following as `/etc/systemd/system/nvidia-pstated.service`.
@@ -169,6 +210,12 @@ Create a new service using `sc.exe` in the elevated command prompt:
 
 ```sh
 sc.exe create nvidia-pstated start=auto binPath="C:\Program Files\nvidia-pstated\nvidia-pstated.exe --service"
+```
+
+Configure the service to be restarted if it crashes, so the GPUs are not left locked to the low performance clocks:
+
+```sh
+sc.exe failure nvidia-pstated reset= 0 actions= restart/60000/restart/60000/restart/60000
 ```
 
 Then start the service:

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,42 @@
               description = "nvidia-pstated package to use";
             };
 
+            clockMode = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Control the GPU clocks instead of the performance states.
+
+                Required for GPUs that expose only a single performance state
+                (Tesla P100, V100, etc). Needs root, so the service does not run
+                as a dynamic user when this is enabled.
+              '';
+            };
+
+            clockGpuLow = mkOption {
+              type = types.int;
+              default = 0;
+              description = "Low performance graphics clock in MHz, in clock mode (0 = the lowest supported clock)";
+            };
+
+            clockGpuHigh = mkOption {
+              type = types.int;
+              default = 0;
+              description = "High performance graphics clock in MHz, in clock mode (0 = the default clocks)";
+            };
+
+            clockMemLow = mkOption {
+              type = types.int;
+              default = 0;
+              description = "Low performance memory clock in MHz, in clock mode (0 = unmanaged on Volta and newer)";
+            };
+
+            clockMemHigh = mkOption {
+              type = types.int;
+              default = 0;
+              description = "High performance memory clock in MHz, in clock mode (0 = unmanaged on Volta and newer)";
+            };
+
             ids = mkOption {
               type = types.str;
               default = "";
@@ -150,7 +186,9 @@
               wantedBy = [ "multi-user.target" ];
 
               serviceConfig = {
-                DynamicUser = true;
+                # Setting the clocks requires root, so a dynamic user is only used
+                # when the daemon manages performance states
+                DynamicUser = !config.services.nvidia-pstated.clockMode;
                 ExecStart =
                   let
                     args = [
@@ -171,19 +209,40 @@
                       "--iterations-before-keepalive"
                       (toString config.services.nvidia-pstated.iterationsBeforeKeepalive)
                     ]
-                    ++ optional (config.services.nvidia-pstated.ids != "") [
+                    ++ optionals config.services.nvidia-pstated.clockMode (
+                      [
+                        "--clock-mode"
+                      ]
+                      ++ optionals (config.services.nvidia-pstated.clockGpuLow != 0) [
+                        "--clock-gpu-low"
+                        (toString config.services.nvidia-pstated.clockGpuLow)
+                      ]
+                      ++ optionals (config.services.nvidia-pstated.clockGpuHigh != 0) [
+                        "--clock-gpu-high"
+                        (toString config.services.nvidia-pstated.clockGpuHigh)
+                      ]
+                      ++ optionals (config.services.nvidia-pstated.clockMemLow != 0) [
+                        "--clock-mem-low"
+                        (toString config.services.nvidia-pstated.clockMemLow)
+                      ]
+                      ++ optionals (config.services.nvidia-pstated.clockMemHigh != 0) [
+                        "--clock-mem-high"
+                        (toString config.services.nvidia-pstated.clockMemHigh)
+                      ]
+                    )
+                    ++ optionals (config.services.nvidia-pstated.ids != "") [
                       "--ids"
                       config.services.nvidia-pstated.ids
                     ]
-                    ++ optional (config.services.nvidia-pstated.disableFanScript != "") [
+                    ++ optionals (config.services.nvidia-pstated.disableFanScript != "") [
                       "--disable-fan-script"
                       config.services.nvidia-pstated.disableFanScript
                     ]
-                    ++ optional (config.services.nvidia-pstated.enableFanScript != "") [
+                    ++ optionals (config.services.nvidia-pstated.enableFanScript != "") [
                       "--enable-fan-script"
                       config.services.nvidia-pstated.enableFanScript
                     ]
-                    ++ optional (config.services.nvidia-pstated.keepaliveFanScript != "") [
+                    ++ optionals (config.services.nvidia-pstated.keepaliveFanScript != "") [
                       "--keepalive-fan-script"
                       config.services.nvidia-pstated.keepaliveFanScript
                     ];

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,18 @@
 
 /***** ***** ***** ***** ***** CONSTANTS ***** ***** ***** ***** *****/
 
+// Graphics clock (in MHz) for the high performance state in clock mode (0 = default clocks)
+#define CLOCK_GPU_HIGH 0
+
+// Graphics clock (in MHz) for the low performance state in clock mode (0 = lowest supported clock)
+#define CLOCK_GPU_LOW 0
+
+// Memory clock (in MHz) for the high performance state in clock mode (0 = memory clocks are not managed)
+#define CLOCK_MEM_HIGH 0
+
+// Memory clock (in MHz) for the low performance state in clock mode (0 = memory clocks are not managed)
+#define CLOCK_MEM_LOW 0
+
 // Number of iterations to wait before considering disabling the fan
 #define ITERATIONS_BEFORE_IDLE 9000
 
@@ -55,6 +67,12 @@ typedef struct {
 
   // Flag to prevent idle ticks
   bool preventIdleTick;
+
+  // Lowest graphics clock (in MHz) supported by the GPU
+  unsigned int lowestGpuClock;
+
+  // Lowest memory clock (in MHz) supported by the GPU
+  unsigned int lowestMemClock;
 } gpuState;
 
 /***** ***** ***** ***** ***** VARIABLES ***** ***** ***** ***** *****/
@@ -93,6 +111,18 @@ static unsigned int idleTime = 0;
 
 // Variable to store keepalive iterations
 static unsigned int keepaliveIterations = 0;
+
+// Flag indicating whether clock control is used instead of performance states
+static bool clockMode = false;
+
+// Flag indicating whether memory clocks are managed in clock mode
+static bool manageMemoryClocks = false;
+
+// Variables to store the clocks used in clock mode
+static unsigned long clockGpuHigh = CLOCK_GPU_HIGH;
+static unsigned long clockGpuLow = CLOCK_GPU_LOW;
+static unsigned long clockMemHigh = CLOCK_MEM_HIGH;
+static unsigned long clockMemLow = CLOCK_MEM_LOW;
 
 /***** ***** ***** ***** ***** FUNCTIONS ***** ***** ***** ***** *****/
 
@@ -166,6 +196,239 @@ static bool enter_pstate(unsigned int i, unsigned int pstateId) {
   return false;
 }
 
+static bool get_lowest_clocks(unsigned int i) {
+  // Variable to hold the list of supported clocks
+  unsigned int * clocks = NULL;
+
+  // Get the current state of the GPU
+  gpuState * state = &gpuStates[i];
+
+  // If GPU are unmanaged
+  if (!state->managed) {
+    // Return true to indicate success
+    return true;
+  }
+
+  /***** MEMORY CLOCK *****/
+  {
+    // NVML does not provide a constant for the number of supported clocks, so probe with a
+    // single element buffer to let NVML report how many elements it actually needs
+    unsigned int probe[1];
+    unsigned int count = 1;
+
+    // Get the number of supported memory clocks
+    NVML_CALL_QUERY_SIZE(nvmlDeviceGetSupportedMemoryClocks(nvmlDevices[i], &count, probe), failure);
+
+    // If the GPU does not report any memory clock
+    if (count == 0) {
+      // Print the error message to standard error
+      fprintf(stderr, "GPU %u does not report any supported memory clock\n", i);
+
+      // Jump to the failure handling code
+      goto failure;
+    }
+
+    // Allocate the list of supported memory clocks
+    SAFE_MALLOC(clocks, count * sizeof(*clocks), failure);
+
+    // Get the supported memory clocks
+    NVML_CALL(nvmlDeviceGetSupportedMemoryClocks(nvmlDevices[i], &count, clocks), failure);
+
+    // Assume the first clock is the lowest one
+    state->lowestMemClock = clocks[0];
+
+    // Look for a lower clock in the remaining ones
+    for (unsigned int j = 1; j < count; j++) {
+      if (clocks[j] < state->lowestMemClock) {
+        state->lowestMemClock = clocks[j];
+      }
+    }
+
+    // Free the list of supported memory clocks
+    SAFE_FREE(clocks);
+  }
+
+  /***** GRAPHICS CLOCK *****/
+  {
+    // NVML reports the supported graphics clocks for a given memory clock, so query the ones
+    // available at the lowest memory clock, which is the lowest operating point of the GPU
+    unsigned int probe[1];
+    unsigned int count = 1;
+
+    // Get the number of supported graphics clocks
+    NVML_CALL_QUERY_SIZE(nvmlDeviceGetSupportedGraphicsClocks(nvmlDevices[i], state->lowestMemClock, &count, probe), failure);
+
+    // If the GPU does not report any graphics clock
+    if (count == 0) {
+      // Print the error message to standard error
+      fprintf(stderr, "GPU %u does not report any supported graphics clock\n", i);
+
+      // Jump to the failure handling code
+      goto failure;
+    }
+
+    // Allocate the list of supported graphics clocks
+    SAFE_MALLOC(clocks, count * sizeof(*clocks), failure);
+
+    // Get the supported graphics clocks
+    NVML_CALL(nvmlDeviceGetSupportedGraphicsClocks(nvmlDevices[i], state->lowestMemClock, &count, clocks), failure);
+
+    // Assume the first clock is the lowest one
+    state->lowestGpuClock = clocks[0];
+
+    // Look for a lower clock in the remaining ones
+    for (unsigned int j = 1; j < count; j++) {
+      if (clocks[j] < state->lowestGpuClock) {
+        state->lowestGpuClock = clocks[j];
+      }
+    }
+
+    // Free the list of supported graphics clocks
+    SAFE_FREE(clocks);
+  }
+
+  // Print the lowest clocks of the GPU
+  printf("GPU %u lowest clocks: %u MHz (graphics), %u MHz (memory)\n", i, state->lowestGpuClock, state->lowestMemClock);
+
+  // Return true to indicate success
+  return true;
+
+  failure:
+  // Free the list of supported clocks
+  SAFE_FREE(clocks);
+
+  // Return false to indicate failure
+  return false;
+}
+
+static bool enter_clockstate(unsigned int i, unsigned int pstateId, bool highPerformance) {
+  // Get the current state of the GPU
+  gpuState * state = &gpuStates[i];
+
+  // If GPU are unmanaged
+  if (!state->managed) {
+    // Return true to indicate success
+    return true;
+  }
+
+  // Variable to hold the graphics clock to use
+  unsigned int gpuClock;
+
+  // If the GPU should enter the high performance state
+  if (highPerformance) {
+    // Use the configured high performance graphics clock
+    gpuClock = (unsigned int) clockGpuHigh;
+  } else {
+    // Use the configured low performance graphics clock, or the lowest supported one
+    gpuClock = clockGpuLow != 0 ? (unsigned int) clockGpuLow : state->lowestGpuClock;
+  }
+
+  // If a graphics clock is requested
+  if (gpuClock != 0) {
+    // Lock the graphics clock of the GPU to it
+    NVML_CALL(nvmlDeviceSetGpuLockedClocks(nvmlDevices[i], gpuClock, gpuClock), failure);
+  } else {
+    // Otherwise, restore the default graphics clock of the GPU
+    NVML_CALL(nvmlDeviceResetGpuLockedClocks(nvmlDevices[i]), failure);
+  }
+
+  // If memory clocks are managed
+  if (manageMemoryClocks) {
+    // Variable to hold the memory clock to use
+    unsigned int memClock;
+
+    // If the GPU should enter the high performance state
+    if (highPerformance) {
+      // Use the configured high performance memory clock
+      memClock = (unsigned int) clockMemHigh;
+    } else {
+      // Use the configured low performance memory clock, or the lowest supported one
+      memClock = clockMemLow != 0 ? (unsigned int) clockMemLow : state->lowestMemClock;
+    }
+
+    // If a memory clock is requested
+    if (memClock != 0) {
+      // Lock the memory clock of the GPU to it
+      NVML_CALL(nvmlDeviceSetMemoryLockedClocks(nvmlDevices[i], memClock, memClock), failure);
+    } else {
+      // Otherwise, restore the default memory clock of the GPU
+      NVML_CALL(nvmlDeviceResetMemoryLockedClocks(nvmlDevices[i]), failure);
+    }
+  }
+
+  // Reset the iteration counter
+  state->iterations = 0;
+
+  // Update the GPU state with the new performance state
+  state->pstateId = pstateId;
+
+  // Print the current GPU state
+  if (gpuClock != 0) {
+    printf("GPU %u entered clock state %u MHz\n", i, gpuClock);
+  } else {
+    printf("GPU %u entered clock state default\n", i);
+  }
+
+  // Return true to indicate success
+  return true;
+
+  failure:
+  // Return false to indicate failure
+  return false;
+}
+
+static bool reset_clockstate(unsigned int i) {
+  // Get the current state of the GPU
+  gpuState * state = &gpuStates[i];
+
+  // If GPU are unmanaged
+  if (!state->managed) {
+    // Return true to indicate success
+    return true;
+  }
+
+  // Restore the default graphics clock of the GPU
+  NVML_CALL(nvmlDeviceResetGpuLockedClocks(nvmlDevices[i]), failure);
+
+  // If memory clocks are managed
+  if (manageMemoryClocks) {
+    // Restore the default memory clock of the GPU
+    NVML_CALL(nvmlDeviceResetMemoryLockedClocks(nvmlDevices[i]), failure);
+  }
+
+  // Print the current GPU state
+  printf("GPU %u clocks restored to default\n", i);
+
+  // Return true to indicate success
+  return true;
+
+  failure:
+  // Return false to indicate failure
+  return false;
+}
+
+static bool enter_state(unsigned int i, unsigned int pstateId, bool highPerformance) {
+  // If clock control is used instead of performance states
+  if (clockMode) {
+    // Set the clocks of the GPU
+    return enter_clockstate(i, pstateId, highPerformance);
+  }
+
+  // Set the performance state of the GPU
+  if (!enter_pstate(i, pstateId)) {
+    // Some GPUs (Tesla P100, V100, etc) expose a single performance state and always reject this
+    // call, so point at clock mode instead of silently switching to it, as the call may also fail
+    // because of an invalid performance state, a driver failure, or any other unrelated reason
+    fprintf(stderr, "If GPU %u does not support performance states, restart the daemon with --clock-mode.\n", i);
+
+    // Return false to indicate failure
+    return false;
+  }
+
+  // Return true to indicate success
+  return true;
+}
+
 static int run(int argc, char * argv[]) {
   /***** OPTIONS *****/
   char * disableFanScript = NULL;
@@ -196,6 +459,36 @@ static int run(int argc, char * argv[]) {
       if ((IS_OPTION("-h") || IS_OPTION("--help"))) {
         // Print usage instructions
         goto usage;
+      }
+
+      // Check if the option is "-c" or "--clock-mode"
+      if ((IS_OPTION("-c") || IS_OPTION("--clock-mode"))) {
+        // Use clock control instead of performance states
+        clockMode = true;
+      }
+
+      // Check if the option is "-cgh" or "--clock-gpu-high" and if there is a next argument
+      if ((IS_OPTION("-cgh") || IS_OPTION("--clock-gpu-high")) && HAS_NEXT_ARG) {
+        // Parse the integer option and store it in clockGpuHigh
+        ASSERT_TRUE(parse_ulong(argv[++i], &clockGpuHigh), usage);
+      }
+
+      // Check if the option is "-cgl" or "--clock-gpu-low" and if there is a next argument
+      if ((IS_OPTION("-cgl") || IS_OPTION("--clock-gpu-low")) && HAS_NEXT_ARG) {
+        // Parse the integer option and store it in clockGpuLow
+        ASSERT_TRUE(parse_ulong(argv[++i], &clockGpuLow), usage);
+      }
+
+      // Check if the option is "-cmh" or "--clock-mem-high" and if there is a next argument
+      if ((IS_OPTION("-cmh") || IS_OPTION("--clock-mem-high")) && HAS_NEXT_ARG) {
+        // Parse the integer option and store it in clockMemHigh
+        ASSERT_TRUE(parse_ulong(argv[++i], &clockMemHigh), usage);
+      }
+
+      // Check if the option is "-cml" or "--clock-mem-low" and if there is a next argument
+      if ((IS_OPTION("-cml") || IS_OPTION("--clock-mem-low")) && HAS_NEXT_ARG) {
+        // Parse the integer option and store it in clockMemLow
+        ASSERT_TRUE(parse_ulong(argv[++i], &clockMemLow), usage);
       }
 
       // Check if the option is "-dfs" or "("--disable-fan-script" and if there is a next argument
@@ -280,6 +573,11 @@ static int run(int argc, char * argv[]) {
       printf("Usage: %s [options]\n", argv[0]);
       printf("\n");
       printf("Options:\n");
+      printf("  -c, --clock-mode                            Control the GPU clocks instead of the performance states (default: disabled)\n");
+      printf("  -cgh, --clock-gpu-high <value>              Set the high performance graphics clock in MHz, in clock mode (default: %u, the default clocks)\n", CLOCK_GPU_HIGH);
+      printf("  -cgl, --clock-gpu-low <value>               Set the low performance graphics clock in MHz, in clock mode (default: %u, the lowest supported clock)\n", CLOCK_GPU_LOW);
+      printf("  -cmh, --clock-mem-high <value>              Set the high performance memory clock in MHz, in clock mode (default: %u, memory clocks are not managed)\n", CLOCK_MEM_HIGH);
+      printf("  -cml, --clock-mem-low <value>               Set the low performance memory clock in MHz, in clock mode (default: %u, memory clocks are not managed)\n", CLOCK_MEM_LOW);
       printf("  -dfs, --disable-fan-script <value>          Script to run when the GPU fan should be disabled (default: none)\n");
       printf("  -efs, --enable-fan-script <value>           Script to run when the GPU fan should be enabled (default: none)\n");
       printf("  -i, --ids <value><,value...>                Set the GPU(s) to control (default: all)\n");
@@ -422,6 +720,11 @@ static int run(int argc, char * argv[]) {
     }
 
     // Print remaining variables
+    printf("clockGpuHigh = %lu\n", clockGpuHigh);
+    printf("clockGpuLow = %lu\n", clockGpuLow);
+    printf("clockMemHigh = %lu\n", clockMemHigh);
+    printf("clockMemLow = %lu\n", clockMemLow);
+    printf("clockMode = %s\n", clockMode ? "true" : "false");
     printf("disableFanScript = %s\n", disableFanScript ? disableFanScript : "N/A");
     printf("enableFanScript = %s\n", enableFanScript ? enableFanScript : "N/A");
     printf("iterationsBeforeIdle = %lu\n", iterationsBeforeIdle);
@@ -503,10 +806,23 @@ static int run(int argc, char * argv[]) {
     // Print the number of GPUs being managed
     printf("Managing %u GPUs...\n", managedGPUs);
 
+    // If clock control is used instead of performance states
+    if (clockMode) {
+      // Manage the memory clocks only when the user asks for it, as locking them requires an
+      // Ampere or newer GPU, while locking the graphics clocks only requires a Volta or newer one
+      manageMemoryClocks = clockMemHigh != 0 || clockMemLow != 0;
+
+      // Iterate through each GPU
+      for (unsigned int i = 0; i < deviceCount; i++) {
+        // Retrieve the lowest clocks supported by the GPU
+        ASSERT_TRUE(get_lowest_clocks(i), errored);
+      }
+    }
+
     // Iterate through each GPU
     for (unsigned int i = 0; i < deviceCount; i++) {
       // Switch to low performance state
-      if (!enter_pstate(i, performanceStateLow)) {
+      if (!enter_state(i, performanceStateLow, false)) {
         goto errored;
       }
 
@@ -626,7 +942,7 @@ static int run(int argc, char * argv[]) {
           // If the GPU is not already in low performance state
           if (state->pstateId != performanceStateLow) {
             // Switch to low performance state
-            if (!enter_pstate(i, performanceStateLow)) {
+            if (!enter_state(i, performanceStateLow, false)) {
               goto errored;
             }
 
@@ -652,7 +968,7 @@ static int run(int argc, char * argv[]) {
           // If the GPU is not already in high performance state
           if (state->pstateId != performanceStateHigh) {
             // Switch to high performance state
-            if (!enter_pstate(i, performanceStateHigh)) {
+            if (!enter_state(i, performanceStateHigh, true)) {
               goto errored;
             }
 
@@ -668,7 +984,7 @@ static int run(int argc, char * argv[]) {
             // If the number of iterations exceeds the threshold
             if (state->iterations > iterationsBeforeSwitch) {
               // Switch to low performance state
-              if (!enter_pstate(i, performanceStateLow)) {
+              if (!enter_state(i, performanceStateLow, false)) {
                 goto errored;
               }
             }
@@ -692,9 +1008,17 @@ static int run(int argc, char * argv[]) {
   {
     // Iterate through each GPU
     for (unsigned int i = 0; i < deviceCount; i++) {
-      // Switch to automatic management of performance state
-      if (!enter_pstate(i, 16)) {
-        goto errored;
+      // If clock control is used instead of performance states
+      if (clockMode) {
+        // Restore the default clocks, as the configured high performance clocks may be locked ones
+        if (!reset_clockstate(i)) {
+          goto errored;
+        }
+      } else {
+        // Switch to automatic management of performance state
+        if (!enter_pstate(i, 16)) {
+          goto errored;
+        }
       }
 
       // Enable the fan

--- a/src/main.c
+++ b/src/main.c
@@ -22,10 +22,10 @@
 // Graphics clock (in MHz) for the low performance state in clock mode (0 = lowest supported clock)
 #define CLOCK_GPU_LOW 0
 
-// Memory clock (in MHz) for the high performance state in clock mode (0 = memory clocks are not managed)
+// Memory clock (in MHz) for the high performance state in clock mode (0 = unmanaged on Volta and newer)
 #define CLOCK_MEM_HIGH 0
 
-// Memory clock (in MHz) for the low performance state in clock mode (0 = memory clocks are not managed)
+// Memory clock (in MHz) for the low performance state in clock mode (0 = unmanaged on Volta and newer)
 #define CLOCK_MEM_LOW 0
 
 // Number of iterations to wait before considering disabling the fan
@@ -73,6 +73,9 @@ typedef struct {
 
   // Lowest memory clock (in MHz) supported by the GPU
   unsigned int lowestMemClock;
+
+  // Flag indicating whether the GPU is older than Volta, and can only use applications clocks
+  bool useApplicationsClocks;
 } gpuState;
 
 /***** ***** ***** ***** ***** VARIABLES ***** ***** ***** ***** *****/
@@ -301,27 +304,27 @@ static bool get_lowest_clocks(unsigned int i) {
   return false;
 }
 
-static bool enter_clockstate(unsigned int i, unsigned int pstateId, bool highPerformance) {
-  // Get the current state of the GPU
-  gpuState * state = &gpuStates[i];
+static bool apply_clocks(unsigned int i, unsigned int gpuClock, unsigned int memClock) {
+  #if NVML_API_VERSION < 14
+    // Get the current state of the GPU
+    gpuState * state = &gpuStates[i];
 
-  // If GPU are unmanaged
-  if (!state->managed) {
-    // Return true to indicate success
-    return true;
-  }
+    // If the GPU is older than Volta, and can only use applications clocks
+    if (state->useApplicationsClocks) {
+      // Applications clocks set both domains in a single call, so a clock is only locked when both
+      // domains are requested, and the default clocks are otherwise restored for both at once
+      if (gpuClock == 0 || memClock == 0) {
+        // Restore the default clocks of the GPU
+        NVML_CALL(nvmlDeviceResetApplicationsClocks(nvmlDevices[i]), failure);
+      } else {
+        // Set the clocks of the GPU
+        NVML_CALL(nvmlDeviceSetApplicationsClocks(nvmlDevices[i], memClock, gpuClock), failure);
+      }
 
-  // Variable to hold the graphics clock to use
-  unsigned int gpuClock;
-
-  // If the GPU should enter the high performance state
-  if (highPerformance) {
-    // Use the configured high performance graphics clock
-    gpuClock = (unsigned int) clockGpuHigh;
-  } else {
-    // Use the configured low performance graphics clock, or the lowest supported one
-    gpuClock = clockGpuLow != 0 ? (unsigned int) clockGpuLow : state->lowestGpuClock;
-  }
+      // Return true to indicate success
+      return true;
+    }
+  #endif
 
   // If a graphics clock is requested
   if (gpuClock != 0) {
@@ -334,18 +337,6 @@ static bool enter_clockstate(unsigned int i, unsigned int pstateId, bool highPer
 
   // If memory clocks are managed
   if (manageMemoryClocks) {
-    // Variable to hold the memory clock to use
-    unsigned int memClock;
-
-    // If the GPU should enter the high performance state
-    if (highPerformance) {
-      // Use the configured high performance memory clock
-      memClock = (unsigned int) clockMemHigh;
-    } else {
-      // Use the configured low performance memory clock, or the lowest supported one
-      memClock = clockMemLow != 0 ? (unsigned int) clockMemLow : state->lowestMemClock;
-    }
-
     // If a memory clock is requested
     if (memClock != 0) {
       // Lock the memory clock of the GPU to it
@@ -354,6 +345,45 @@ static bool enter_clockstate(unsigned int i, unsigned int pstateId, bool highPer
       // Otherwise, restore the default memory clock of the GPU
       NVML_CALL(nvmlDeviceResetMemoryLockedClocks(nvmlDevices[i]), failure);
     }
+  }
+
+  // Return true to indicate success
+  return true;
+
+  failure:
+  // Return false to indicate failure
+  return false;
+}
+
+static bool enter_clockstate(unsigned int i, unsigned int pstateId, bool highPerformance) {
+  // Get the current state of the GPU
+  gpuState * state = &gpuStates[i];
+
+  // If GPU are unmanaged
+  if (!state->managed) {
+    // Return true to indicate success
+    return true;
+  }
+
+  // Variables to hold the clocks to use
+  unsigned int gpuClock;
+  unsigned int memClock;
+
+  // If the GPU should enter the high performance state
+  if (highPerformance) {
+    // Use the configured high performance clocks
+    gpuClock = (unsigned int) clockGpuHigh;
+    memClock = (unsigned int) clockMemHigh;
+  } else {
+    // Use the configured low performance clocks, or the lowest supported ones
+    gpuClock = clockGpuLow != 0 ? (unsigned int) clockGpuLow : state->lowestGpuClock;
+    memClock = clockMemLow != 0 ? (unsigned int) clockMemLow : state->lowestMemClock;
+  }
+
+  // Set the clocks of the GPU
+  if (!apply_clocks(i, gpuClock, memClock)) {
+    // Return false to indicate failure
+    return false;
   }
 
   // Reset the iteration counter
@@ -371,10 +401,6 @@ static bool enter_clockstate(unsigned int i, unsigned int pstateId, bool highPer
 
   // Return true to indicate success
   return true;
-
-  failure:
-  // Return false to indicate failure
-  return false;
 }
 
 static bool reset_clockstate(unsigned int i) {
@@ -387,13 +413,10 @@ static bool reset_clockstate(unsigned int i) {
     return true;
   }
 
-  // Restore the default graphics clock of the GPU
-  NVML_CALL(nvmlDeviceResetGpuLockedClocks(nvmlDevices[i]), failure);
-
-  // If memory clocks are managed
-  if (manageMemoryClocks) {
-    // Restore the default memory clock of the GPU
-    NVML_CALL(nvmlDeviceResetMemoryLockedClocks(nvmlDevices[i]), failure);
+  // Restore the default clocks of the GPU
+  if (!apply_clocks(i, 0, 0)) {
+    // Return false to indicate failure
+    return false;
   }
 
   // Print the current GPU state
@@ -401,10 +424,6 @@ static bool reset_clockstate(unsigned int i) {
 
   // Return true to indicate success
   return true;
-
-  failure:
-  // Return false to indicate failure
-  return false;
 }
 
 static bool enter_state(unsigned int i, unsigned int pstateId, bool highPerformance) {
@@ -576,8 +595,8 @@ static int run(int argc, char * argv[]) {
       printf("  -c, --clock-mode                            Control the GPU clocks instead of the performance states (default: disabled)\n");
       printf("  -cgh, --clock-gpu-high <value>              Set the high performance graphics clock in MHz, in clock mode (default: %u, the default clocks)\n", CLOCK_GPU_HIGH);
       printf("  -cgl, --clock-gpu-low <value>               Set the low performance graphics clock in MHz, in clock mode (default: %u, the lowest supported clock)\n", CLOCK_GPU_LOW);
-      printf("  -cmh, --clock-mem-high <value>              Set the high performance memory clock in MHz, in clock mode (default: %u, memory clocks are not managed)\n", CLOCK_MEM_HIGH);
-      printf("  -cml, --clock-mem-low <value>               Set the low performance memory clock in MHz, in clock mode (default: %u, memory clocks are not managed)\n", CLOCK_MEM_LOW);
+      printf("  -cmh, --clock-mem-high <value>              Set the high performance memory clock in MHz, in clock mode (default: %u, unmanaged on Volta and newer)\n", CLOCK_MEM_HIGH);
+      printf("  -cml, --clock-mem-low <value>               Set the low performance memory clock in MHz, in clock mode (default: %u, unmanaged on Volta and newer)\n", CLOCK_MEM_LOW);
       printf("  -dfs, --disable-fan-script <value>          Script to run when the GPU fan should be disabled (default: none)\n");
       printf("  -efs, --enable-fan-script <value>           Script to run when the GPU fan should be enabled (default: none)\n");
       printf("  -i, --ids <value><,value...>                Set the GPU(s) to control (default: all)\n");
@@ -814,6 +833,40 @@ static int run(int argc, char * argv[]) {
 
       // Iterate through each GPU
       for (unsigned int i = 0; i < deviceCount; i++) {
+        // Get the current state of the GPU
+        gpuState * state = &gpuStates[i];
+
+        // If GPU is unmanaged
+        if (!state->managed) {
+          // Skip to the next GPU
+          continue;
+        }
+
+        // Variable to hold the architecture of the GPU
+        nvmlDeviceArchitecture_t architecture;
+
+        // Retrieve the architecture of the GPU
+        NVML_CALL(nvmlDeviceGetArchitecture(nvmlDevices[i], &architecture), errored);
+
+        // Locked clocks require a Volta or newer GPU, so older ones have to use applications
+        // clocks. Checking the architecture is enough to know applications clocks are available:
+        // the last driver branch supporting pre-Volta GPUs is 580, which still provides them
+        if (architecture < NVML_DEVICE_ARCH_VOLTA) {
+          #if NVML_API_VERSION < 14
+            // Use applications clocks for this GPU
+            state->useApplicationsClocks = true;
+
+            // Print the clock control mechanism used for the GPU
+            printf("GPU %u is older than Volta, using applications clocks\n", i);
+          #else
+            // Print the error message to standard error
+            fprintf(stderr, "GPU %u is older than Volta, and this build does not support applications clocks\n", i);
+
+            // Jump to error handling section
+            goto errored;
+          #endif
+        }
+
         // Retrieve the lowest clocks supported by the GPU
         ASSERT_TRUE(get_lowest_clocks(i), errored);
       }

--- a/src/nvml.h
+++ b/src/nvml.h
@@ -20,3 +20,20 @@
     goto label;                                                  \
   }                                                              \
 } while (0)
+
+// Macro to simplify NVML function calls that query the size of an array.
+// Such calls report the number of required elements through their count
+// argument, so a buffer that is too small is an expected result, not an error.
+#define NVML_CALL_QUERY_SIZE(call, label) do {                   \
+  /* Evaluate the NVML function call and store the result */     \
+  nvmlReturn_t result = (call);                                  \
+                                                                 \
+  /* Check if the result indicates an error */                   \
+  if (result != NVML_SUCCESS && result != NVML_ERROR_INSUFFICIENT_SIZE) { \
+    /* Print the error message to standard error */              \
+    fprintf(stderr, "%s: %s\n", #call, nvmlErrorString(result)); \
+                                                                 \
+    /* Jump to the specified label */                            \
+    goto label;                                                  \
+  }                                                              \
+} while (0)

--- a/src/nvml.h
+++ b/src/nvml.h
@@ -7,12 +7,12 @@
 /***** ***** ***** ***** ***** MACROS ***** ***** ***** ***** *****/
 
 // Macro to simplify NVML function calls and handle errors
-#define NVML_CALL(call, label) do {                              \
+#define NVML_CALL_TOLERATE(call, tolerated, label) do {          \
   /* Evaluate the NVML function call and store the result */     \
   nvmlReturn_t result = (call);                                  \
                                                                  \
   /* Check if the result indicates an error */                   \
-  if (result != NVML_SUCCESS) {                                  \
+  if (result != NVML_SUCCESS && result != (tolerated)) {         \
     /* Print the error message to standard error */              \
     fprintf(stderr, "%s: %s\n", #call, nvmlErrorString(result)); \
                                                                  \
@@ -21,19 +21,8 @@
   }                                                              \
 } while (0)
 
-// Macro to simplify NVML function calls that query the size of an array.
-// Such calls report the number of required elements through their count
-// argument, so a buffer that is too small is an expected result, not an error.
-#define NVML_CALL_QUERY_SIZE(call, label) do {                   \
-  /* Evaluate the NVML function call and store the result */     \
-  nvmlReturn_t result = (call);                                  \
-                                                                 \
-  /* Check if the result indicates an error */                   \
-  if (result != NVML_SUCCESS && result != NVML_ERROR_INSUFFICIENT_SIZE) { \
-    /* Print the error message to standard error */              \
-    fprintf(stderr, "%s: %s\n", #call, nvmlErrorString(result)); \
-                                                                 \
-    /* Jump to the specified label */                            \
-    goto label;                                                  \
-  }                                                              \
-} while (0)
+#define NVML_CALL(call, label) \
+  NVML_CALL_TOLERATE(call, NVML_SUCCESS, label)
+
+#define NVML_CALL_QUERY_SIZE(call, label) \
+  NVML_CALL_TOLERATE(call, NVML_ERROR_INSUFFICIENT_SIZE, label)


### PR DESCRIPTION
It falls back to "Clock mode" when establishing the P-state fails. Then it checks the lowest supported frequency (GPU and VRAM) for each GPU and uses those frequencies.