### PR TITLE
Add Nix flake and NixOS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,43 @@ cmake -B build
 cmake --build build
 ```
 
+### Nix
+
+This project provides a Nix flake to build the binary:
+
+```sh
+nix build
+```
+
+**NixOS Module:**
+
+The flake also provides a NixOS module. To use it, add the flake to your inputs and import the module in your NixOS configuration.
+
+`flake.nix`:
+```nix
+{
+  inputs.nvidia-pstated.url = "github:sasha0552/nvidia-pstated";
+
+  outputs = { self, nixpkgs, nvidia-pstated }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      # ...
+      modules = [
+        ./configuration.nix
+        nvidia-pstated.nixosModules.default
+      ];
+    };
+  };
+}
+```
+
+`configuration.nix`:
+```nix
+{ config, pkgs, ... }: {
+  # ...
+  services.nvidia-pstated.enable = true;
+}
+```
+
 ## Misc
 
 ### Managing only specific GPUs
@@ -172,7 +209,7 @@ For example, I have a server fans connected to AC 220v -> DC 12v PSU. I'm using 
 `nvidia-pstated --disable-fan-script 'curl --output /dev/null --silent "http://x.x.x.x/cm?cmnd=POWER%20OFF"' --enable-fan-script 'curl --output /dev/null --silent "http://x.x.x.x/cm?cmnd=POWER%20ON"'`
 
 By default, nvidia-pstated:
-1. Disables the fans at startup 
+1. Disables the fans at startup
 2. Enables the fans when the GPUs are overheated (`--temperature-threshold`)
 3. Enables the fans when switching to high performance state
 4. Disables the fans when idling for 15 minutes (when not overheated)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761597516,
+        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nvapi-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718895301,
+        "narHash": "sha256-XA3/Gttf4CQFMGbSz+Tp4E2tgunQbUKpd2bnJOFeO5k=",
+        "type": "tarball",
+        "url": "https://download.nvidia.com/XFree86/nvapi-open-source-sdk/R555-OpenSource.tar"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://download.nvidia.com/XFree86/nvapi-open-source-sdk/R555-OpenSource.tar"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nvapi-src": "nvapi-src"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A Nix-native driver for NVIDIA GPUs";
+  description = "A daemon that automatically manages the performance states of NVIDIA GPUs";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
@@ -52,5 +52,130 @@
         type = "app";
         program = "${self.packages.${system}.default}/bin/nvidia-pstated";
       };
+
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        with lib;
+        {
+          options.services.nvidia-pstated = {
+            enable = mkEnableOption "nvidia-pstated daemon";
+
+            package = mkOption {
+              type = types.package;
+              default = self.packages.${system}.default;
+              description = "nvidia-pstated package to use";
+            };
+
+            ids = mkOption {
+              type = types.str;
+              default = "";
+              description = "Comma-separated list of GPU IDs to manage (empty = all GPUs)";
+            };
+
+            temperatureThreshold = mkOption {
+              type = types.int;
+              default = 80;
+              description = "Temperature threshold in degrees Celsius";
+            };
+
+            utilizationThreshold = mkOption {
+              type = types.int;
+              default = 0;
+              description = "GPU utilization threshold in percentage";
+            };
+
+            performanceStateLow = mkOption {
+              type = types.int;
+              default = 8;
+              description = "Low performance state value";
+            };
+
+            performanceStateHigh = mkOption {
+              type = types.int;
+              default = 16;
+              description = "High performance state value";
+            };
+
+            sleepInterval = mkOption {
+              type = types.int;
+              default = 100;
+              description = "Sleep interval in milliseconds";
+            };
+
+            iterationsBeforeSwitch = mkOption {
+              type = types.int;
+              default = 30;
+              description = "Number of iterations before switching performance state";
+            };
+
+            iterationsBeforeIdle = mkOption {
+              type = types.int;
+              default = 9000;
+              description = "Number of iterations before considering GPU idle";
+            };
+
+            disableFanScript = mkOption {
+              type = types.str;
+              default = "";
+              description = "Script to run when disabling external fans";
+            };
+
+            enableFanScript = mkOption {
+              type = types.str;
+              default = "";
+              description = "Script to run when enabling external fans";
+            };
+          };
+
+          config = mkIf config.services.nvidia-pstated.enable {
+            systemd.services.nvidia-pstated = {
+              description = "A daemon that automatically manages the performance states of NVIDIA GPUs";
+              wantedBy = [ "multi-user.target" ];
+
+              serviceConfig = {
+                DynamicUser = true;
+                ExecStart =
+                  let
+                    args = [
+                      "--temperature-threshold"
+                      (toString config.services.nvidia-pstated.temperatureThreshold)
+                      "--utilization-threshold"
+                      (toString config.services.nvidia-pstated.utilizationThreshold)
+                      "--performance-state-low"
+                      (toString config.services.nvidia-pstated.performanceStateLow)
+                      "--performance-state-high"
+                      (toString config.services.nvidia-pstated.performanceStateHigh)
+                      "--sleep-interval"
+                      (toString config.services.nvidia-pstated.sleepInterval)
+                      "--iterations-before-switch"
+                      (toString config.services.nvidia-pstated.iterationsBeforeSwitch)
+                      "--iterations-before-idle"
+                      (toString config.services.nvidia-pstated.iterationsBeforeIdle)
+                    ]
+                    ++ optional (config.services.nvidia-pstated.ids != "") [
+                      "--ids"
+                      config.services.nvidia-pstated.ids
+                    ]
+                    ++ optional (config.services.nvidia-pstated.disableFanScript != "") [
+                      "--disable-fan-script"
+                      config.services.nvidia-pstated.disableFanScript
+                    ]
+                    ++ optional (config.services.nvidia-pstated.enableFanScript != "") [
+                      "--enable-fan-script"
+                      config.services.nvidia-pstated.enableFanScript
+                    ];
+                  in
+                  "${config.services.nvidia-pstated.package}/bin/nvidia-pstated ${concatStringsSep " " args}";
+                Restart = "on-failure";
+                RestartSec = "1s";
+              };
+            };
+          };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,18 @@
               default = "";
               description = "Script to run when enabling external fans";
             };
+
+            keepaliveFanScript = mkOption {
+              type = types.str;
+              default = "";
+              description = "Script to run periodically, with the intended state of the external fans";
+            };
+
+            iterationsBeforeKeepalive = mkOption {
+              type = types.int;
+              default = 10;
+              description = "Set the number of iterations to wait before executing keepalive script again";
+            };
           };
 
           config = mkIf config.services.nvidia-pstated.enable {
@@ -156,6 +168,8 @@
                       (toString config.services.nvidia-pstated.iterationsBeforeSwitch)
                       "--iterations-before-idle"
                       (toString config.services.nvidia-pstated.iterationsBeforeIdle)
+                      "--iterations-before-keepalive"
+                      (toString config.services.nvidia-pstated.iterationsBeforeKeepalive)
                     ]
                     ++ optional (config.services.nvidia-pstated.ids != "") [
                       "--ids"
@@ -168,6 +182,10 @@
                     ++ optional (config.services.nvidia-pstated.enableFanScript != "") [
                       "--enable-fan-script"
                       config.services.nvidia-pstated.enableFanScript
+                    ]
+                    ++ optional (config.services.nvidia-pstated.keepaliveFanScript != "") [
+                      "--keepalive-fan-script"
+                      config.services.nvidia-pstated.keepaliveFanScript
                     ];
                   in
                   "${config.services.nvidia-pstated.package}/bin/nvidia-pstated ${concatStringsSep " " args}";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "A Nix-native driver for NVIDIA GPUs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nvapi-src = {
+      url = "https://download.nvidia.com/XFree86/nvapi-open-source-sdk/R555-OpenSource.tar";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nvapi-src,
+    }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+    in
+    {
+      packages.${system}.default = pkgs.stdenv.mkDerivation {
+        pname = "nvidia-pstated";
+        version = "0.1.0";
+
+        src = ./.;
+
+        nativeBuildInputs = [
+          pkgs.cmake
+        ];
+
+        buildInputs = [
+          pkgs.cudatoolkit
+          pkgs.linuxPackages.nvidia_x11
+        ];
+
+        cmakeFlags = [
+          "-DFETCHCONTENT_SOURCE_DIR_NVAPI=${nvapi-src}"
+        ];
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp nvidia-pstated $out/bin/
+        '';
+      };
+
+      apps.${system}.default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/nvidia-pstated";
+      };
+    };
+}


### PR DESCRIPTION
This adds a flake.nix to the project, allowing users to build and run nvidia-pstated
in a reproducible way using Nix.

It also introduces a NixOS module that makes it easy to configure and run
nvidia-pstated as a systemd service on NixOS systems. All command-line options are
exposed as NixOS options for easy configuration.

The README.md has been updated to include instructions on how to use the new flake
and NixOS module.